### PR TITLE
Change turbo.state to a string variable.

### DIFF
--- a/common/turbo_exec/turbo_buffer_loop.tpt2
+++ b/common/turbo_exec/turbo_buffer_loop.tpt2
@@ -8,13 +8,15 @@
 ; This script still needs to respect frame change to prevent freezes.
 
 ; This variable is used to recieve state information from `<turbo> register`
-:global int turbo.state
+:global string turbo.state
 
 ; 3 cycles, + the starting cycle is enough to give time to `<turbo> register`
-execute(if(turbo.state != -1, "TE2.0", ""))
-execute(if(turbo.state != -1, "TE2.0", ""))
-execute(if(turbo.state != -1, "TE2.0", ""))
+; The condition seems odd, but state "active" is actually the state where a
+; frame break occurs, so it is the one we must stop on.
+execute(if(turbo.state != "active", "TE2.0", ""))
+execute(if(turbo.state != "active", "TE2.0", ""))
+execute(if(turbo.state != "active", "TE2.0", ""))
 ; By making the last instruction a stop, we active turbo exec from this script
 ; directly, and free up some script space, at the cost of cutting the
 ; cycle a little short for this specific cycle.
-stop(if(turbo.state != -1, "TE2.0 buffer loop", ""))
+stop(if(turbo.state != "active", "TE2.0 buffer loop", ""))

--- a/common/turbo_exec/turbo_cycle_loop.tpt2
+++ b/common/turbo_exec/turbo_cycle_loop.tpt2
@@ -7,13 +7,15 @@
 
 
 ; This variable is used to recieve state information from `<turbo> register`
-:global int turbo.state
+:global string turbo.state
 
 ; Run the script which is gonna reset the cycle. That script is gonna be put
 ; at the current end of the script list, any script that are added to the list
 ; after that are not gonna execute their first instruction until the
 ; next cycle.
-execute(if(turbo.state != -1, "TE2.0", ""))
+; The condition seems odd, but state "active" is actually the state where a
+; frame break occurs, so it is the one we must stop on.
+execute(if(turbo.state != "active", "TE2.0", ""))
 ; Since scripts aren't removed from the script list as long as turbo is
 ; running, their last instructions are instead run every cycle. This allows
 ; repeating this every cycle, as if it were a loop.

--- a/common/turbo_exec/turbo_register.tpt2
+++ b/common/turbo_exec/turbo_register.tpt2
@@ -12,15 +12,16 @@
 :global int turbo.register
 
 ; This variable is used to communicate state with other scripts in turbo,
-; there are 3 states possible :
-; -2 means turbo should stop on the next cycle, this state is used to allow
-;     a 1-cycle delay on when `turbo start` needs to be called to
+; there are 4 states possible :
+; "stopping" means turbo should stop on the next cycle, this state is used to
+;     allow a 1-cycle delay on when `turbo start` needs to be called to
 ;     guarantee that one and only one frame passed from the last `<turbo> stop`
-; -1 means that this cycle is a "breaking" cycle, and forces advancing to the
-;     next frame
-; 0 means that turbo is idle and waiting for the next script to register
-; 1 means that turbo is currently running
-:global int turbo.state
+; "active" means that this cycle is a "breaking" cycle, and forces advancing
+;     to the next frame. The name is chosen because this is what will usually
+;     appear in the variable display when turbo is active.
+; "idle" means that turbo is idle and waiting for the next script to register
+; "running" means that turbo is currently running
+:global string turbo.state
 
 ; This variable counts the number of cycles since the beginning of the frame,
 ; although it does have a delay of a few cycles, this doesn't matter for its
@@ -53,7 +54,7 @@ waituntil(turbo.register > 0) ; Wait for a script to register
 skipwait:
 execute("TE2.0 counting");
 
-turbo.state = 1
+turbo.state = "running"
 
 ; Reset cycles.max to its default value at the start of each frame, even if a
 ; script fails to call `<turbo> stop` in time, it's better to reset this value
@@ -73,10 +74,10 @@ waituntil(turbo.register == 0 || turbo.cycles >= min(turbo.cycles.max, 50000))
 ; The reason we need to buffer for 2 cycles is that one of the cycle is used up
 ; when `execsync("turbo stop")` ends.
 
-turbo.state = -2 ; About to change to the next frame
-wait(0.0) ; Buffered instructions
-turbo.state = -1 ; Changing to the next frame on this cycle
-turbo.state = 0 ; Idle state, waiting for registration
+turbo.state = "stopping" ; About to change to the next frame
+wait(0.0)                ; Buffered instructions
+turbo.state = "active"   ; Changing to the next frame on this cycle
+turbo.state = "idle"     ; Idle state, waiting for registration
 
 ; Save a cycle if registration already happened
 goto(if(turbo.register > 0, skipwait, 1))

--- a/common/turbo_exec/turbo_start.tpt2
+++ b/common/turbo_exec/turbo_start.tpt2
@@ -16,7 +16,7 @@
 :global int turbo.register
 
 ; This variable is used to recieve state information from `<turbo> register`.
-:global int turbo.state
+:global string turbo.state
 
 ; Because `<turbo> register` cannot start turbo on a 0-frame delay for multiple
 ; reasons, the start script launches its own turbo loop which is gonna run for
@@ -30,7 +30,7 @@ turbo.register += 1 ; Increment the registry counter
 ; to `turbo stop`.
 ; `goto` is being used here to stay consistent with `turbo stop`.
 wait:
-goto(if(turbo.state == 1, end, wait))
+goto(if(turbo.state == "running", end, wait))
 
 ; Finishing the script with a noop is important, else the script will get
 ; stuck on the `goto` even after turbo finished.

--- a/common/turbo_exec/turbo_stop.tpt2
+++ b/common/turbo_exec/turbo_stop.tpt2
@@ -19,22 +19,22 @@
 :global int turbo.register
 
 ; This variable is used to recieve state information from `<turbo> register`.
-:global int turbo.state
+:global string turbo.state
 
 ; Decrement the registry counter, with a safeguard in case a script calls
 ; `turbo stop` more times then it's supposed to
 turbo.register = max(0, turbo.register - 1)
 
-; `turbo.state` first goes through the state -2, which happens 1 cycle early
-; By exiting one cycle early, the caller script has a 1 cycle buffer to call
-; `turbo start` again to preserve frame continuity, but since the frame skip
-; is already planned at that point, even if the caller calls `turbo start`
+; `turbo.state` first goes through the state "stopping", which happens 1 cycle
+; early. By exiting one cycle early, the caller script has a 1 cycle buffer to
+; call `turbo start` again to preserve frame continuity, but since the frame
+; skip is already planned at that point, even if the caller calls `turbo start`
 ; right after this exits, the frame will be skipped correctly, this allows more
 ; versatility in the caller's syntax and could save some crucial lines.
 ; It is important to use `goto` here instead of `waituntil`, as else the extra
 ; cycle would be consumed by waiting for the extra noop instruction at the end.
 wait:
-goto(if(turbo.state != 1, end, wait))
+goto(if(turbo.state != "running", end, wait))
 
 ; Finishing the script with a noop is important, else the script will get
 ; stuck on the `goto` even after turbo finished.


### PR DESCRIPTION
Making it a string allows the states to be (slightly) more
self-explanatory, and make more sense to users when displayed in the
global variables list.